### PR TITLE
MBX-3601: Update Example App NC with new extension methods

### DIFF
--- a/example/exampleApp/android/app/build.gradle
+++ b/example/exampleApp/android/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   implementation "com.facebook.react:react-native:0.73.3"
 
   // Integration of Mindbox SDK and necessary Firebase and Huawei services for mobile push notifications functionality
-  implementation 'cloud.mindbox:mobile-sdk:2.10.1'
+  implementation 'cloud.mindbox:mobile-sdk:2.11.0'
   implementation platform('com.google.firebase:firebase-bom:29.3.1')
   implementation 'com.google.firebase:firebase-analytics-ktx'
   implementation 'com.google.firebase:firebase-messaging-ktx'

--- a/example/exampleApp/ios/MindboxNotificationServiceExtension/NotificationService.swift
+++ b/example/exampleApp/ios/MindboxNotificationServiceExtension/NotificationService.swift
@@ -1,6 +1,5 @@
 import UserNotifications
 import MindboxNotifications
-import Mindbox
 
 // https://developers.mindbox.ru/docs/ios-send-rich-push-react-native
 class NotificationService: UNNotificationServiceExtension {
@@ -24,7 +23,7 @@ class NotificationService: UNNotificationServiceExtension {
     // save data from notification to userDefaults
     // don't use userDefault on your application, it's only for example
     func saveNotification(request: UNNotificationRequest) {
-            guard let pushData = Mindbox.shared.getMindboxPushData(userInfo: request.content.userInfo) else {
+            guard let pushData = mindboxService.getMindboxPushData(userInfo: request.content.userInfo) else {
                 print("Failed to get Mindbox push data")
                 return
             }

--- a/example/exampleApp/ios/Podfile
+++ b/example/exampleApp/ios/Podfile
@@ -29,14 +29,14 @@ target 'exampleApp' do
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
-  pod 'Mindbox', '2.10.1'
+  pod 'Mindbox', '2.11.0'
 
 target 'MindboxNotificationServiceExtension' do
-     pod 'MindboxNotifications', '2.10.1'
+     pod 'MindboxNotifications', '2.11.0'
   end
 
 target 'MindboxNotificationContentExtension' do
-   pod 'MindboxNotifications', '2.10.1'
+   pod 'MindboxNotifications', '2.11.0'
   end
 
   post_install do |installer|

--- a/example/exampleApp/ios/exampleApp.xcodeproj/project.pbxproj
+++ b/example/exampleApp/ios/exampleApp.xcodeproj/project.pbxproj
@@ -882,7 +882,10 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -950,7 +953,10 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/example/exampleApp/package.json
+++ b/example/exampleApp/package.json
@@ -13,7 +13,7 @@
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.17",
     "@react-navigation/stack": "^6.3.20",
-    "mindbox-sdk": "^2.10.0",
+    "mindbox-sdk": "^2.11.0",
     "react": "18.2.0",
     "react-native": "0.73.4",
     "react-native-permissions": "^4.1.1",

--- a/example/exampleApp/src/screens/HomeScreen.tsx
+++ b/example/exampleApp/src/screens/HomeScreen.tsx
@@ -13,8 +13,8 @@ const configuration = {
   // Set your endpoints system name for ios and android below
   endpointId:
     Platform.OS === 'ios'
-      ? 'Mpush-test.IosRnExample'
-      : 'Mpush-test.AndroidRnExample',
+      ? ''
+      : '',
   subscribeCustomerIfCreated: true,
   shouldCreateCustomer: true,
 };

--- a/example/exampleApp/src/screens/HomeScreen.tsx
+++ b/example/exampleApp/src/screens/HomeScreen.tsx
@@ -13,8 +13,8 @@ const configuration = {
   // Set your endpoints system name for ios and android below
   endpointId:
     Platform.OS === 'ios'
-      ? ''
-      : '',
+      ? 'Mpush-test.IosRnExample'
+      : 'Mpush-test.AndroidRnExample',
   subscribeCustomerIfCreated: true,
   shouldCreateCustomer: true,
 };


### PR DESCRIPTION
[iOS] Сделать доступными методы isMindboxPush и getMindboxPushData в MindboxNotifications[#3601](https://github.com/mindbox-cloud/issues-web-mobile/issues/3601)

Я здесь не увидел никаких изменений в импорте `Mindbox` в расширение. Вот прям вообще ничего не нашел. [Вот тот PullRequest](https://github.com/mindbox-cloud/react-native-sdk/commit/fa4a9146f3053b26d91584a129d85fc3272b7d7c#diff-a666c0ce43c07d7828b97dd110f3227566acf6e8ab0da27b3b652e0391c5d81e)

Добавил дефолтные endpoint, как во Flutter, чтобы не приходилось каждый раз руками их вбивать 
[Android touchpoint](https://mpush-test.mindbox.ru/newintegrations/e26db878-9ab5-4e97-9f17-6166f1bd7132/edit)
[iOS touchpoint](https://mpush-test.mindbox.ru/newintegrations/0cfc5bd6-b5f6-4b00-9b90-6e82c7221f80/edit)

Нужно будет также здесь версию поднять после релиза