### PR TITLE
GITLAB | change worfklow dispatch to gitlab

### DIFF
--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -1,16 +1,14 @@
 name: Build application after merge
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
-      - 'feature/*'
-      - 'develop'
+      - 'poziev/gitlab-cicd-port'
 
 jobs:
   trigger:
     runs-on: macos-latest
-    if: github.event.pull_request.merged == true
+    #if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -20,11 +18,10 @@ jobs:
           commits=$(git log -3 --pretty=format:"%s")
           echo "commits=$commits" >> $GITHUB_ENV
 
-      - name: Trigger build workflow in react-native-app repo
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          token: ${{ secrets.PAT_REACT_NATIVE_APP }}
-          workflow: buildApplicationAfterTrigger.yml
-          repo: mindbox-cloud/react-native-app
-          ref: develop
-          inputs: '{"branch": "${{ github.head_ref }}", "commits": "${{ env.commits }}"}'
+      - name: trigger build & send to FAD
+        run: |
+          curl --location 'https://mindbox.gitlab.yandexcloud.net/api/v4/projects/1487/trigger/pipeline' \
+            --form 'token="${{ secrets.GITLAB_TRIGGER_TOKEN }}"' \
+            --form 'ref="test_branch"' \
+            --form "variables[INPUT_BRANCH]=\"${{ github.head_ref }}\"" \
+            --form "variables[INPUT_COMMITS]=\"${{ env.commits }}\""

--- a/.github/workflows/trigger-build-app.yml
+++ b/.github/workflows/trigger-build-app.yml
@@ -1,14 +1,16 @@
 name: Build application after merge
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
-      - 'poziev/gitlab-cicd-port'
+      - 'feature/*'
+      - 'develop'
 
 jobs:
   trigger:
     runs-on: macos-latest
-    #if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
В рамках перехода на gitlab, необходимо поменять workflow_dispatch триггер на гитлабовский аналог

- Добавлен секрет GITLAB_TRIGGER_TOKEN для триггера джобы в GitLab
- Добавлен триггер GitLab пайплайна, аналогично android-sdk и ios-sdk

Что изменится при переводе в PR:
- id проекта изменится на id импортированного проекта: 1487 -> x (на данный момент это id тестового CI/CD проекта)
