### PR TITLE
WMSDK-0000: fix issue with iOS target version in example

### DIFF
--- a/example/exampleApp/package.json
+++ b/example/exampleApp/package.json
@@ -21,7 +21,7 @@
     "react-native-gesture-handler": "2.21.2",
     "react-native-permissions": "^5.4.0",
     "react-native-safe-area-context": "^4.9.0",
-    "react-native-screens": "^4.0.0",
+    "react-native-screens": "^3.29.0",
     "react-native-snackbar": "^2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Specs satisfying the `RNScreens (from `../node_modules/react-native-screens`)` dependency were found, but they required a higher minimum deployment target.