### PR TITLE
MOBILE-121: Align Gitleaks workflow indentation with other SDKs

### DIFF
--- a/.github/workflows/gitleaks-secrets-validate.yml
+++ b/.github/workflows/gitleaks-secrets-validate.yml
@@ -11,13 +11,13 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
 
-    - name: Run Gitleaks
-      uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITLEAKS_LICENSE: ${{ secrets.MINDBOX_GITLEAKS_LICENSE }}
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.MINDBOX_GITLEAKS_LICENSE }}


### PR DESCRIPTION
Re-indent steps to the 6-space style used by ios-sdk/flutter-sdk so the Gitleaks workflow is identical across repos. Whitespace-only.